### PR TITLE
Index navigation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -41,10 +41,6 @@ pygmentsStyle = "tango"
     name = "Blog"
     weight = -100
     url = "/blog/"
-[[menu.main]]
-    name = "GitHub"
-    weight = -99
-    url = "https://github.com/imageworks/OpenCue"
 
  # First one is picked as the Twitter card image if not set on page.
  #images = ["images/project-illustration.png"]

--- a/config.toml
+++ b/config.toml
@@ -27,6 +27,25 @@ pygmentsUseClassic = false
 # See https://help.farbox.com/pygments.html
 pygmentsStyle = "tango"
 
+# Top-level navigation (horizontal)
+
+[[menu.main]]
+    name = "What is OpenCue?"
+    weight = -103
+    url = "/docs/concepts/opencue-overview"
+[[menu.main]]
+    name = "Documentation"
+    weight = -101
+    url = "/docs/"
+[[menu.main]]
+    name = "Blog"
+    weight = -100
+    url = "/blog/"
+[[menu.main]]
+    name = "GitHub"
+    weight = -99
+    url = "https://github.com/imageworks/OpenCue"
+
  # First one is picked as the Twitter card image if not set on page.
  #images = ["images/project-illustration.png"]
 

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -1,9 +1,6 @@
 ---
 title: "OpenCue Blog"
 linkTitle: "Blog"
-menu:
-  main:
-    weight: 30
 ---
 
 

--- a/content/en/docs/Concepts/_index.md
+++ b/content/en/docs/Concepts/_index.md
@@ -3,11 +3,8 @@ title: "Concepts"
 linkTitle: "Concepts"
 weight: 1
 description: >
-  A short lead descripton about this section page. Text here can also be **bold** or _italic_ and can even be split over multiple paragraphs.
+  Understanding OpenCue concepts and terminology for all users
 ---
 
-This is the section landing page.
-
-* Summarize
-* Your section
-* Here
+*   [OpenCue overview](/docs/concepts/opencue-overview)
+*   [Glossary](/docs/concepts/glossary)

--- a/content/en/docs/Concepts/opencue-overview.md
+++ b/content/en/docs/Concepts/opencue-overview.md
@@ -1,10 +1,7 @@
 ---
 title: "OpenCue overview"
-linkTitle: "What is OpenCue?"
+linkTitle: "OpenCue overview"
 weight: 1
-menu:
-  main:
-    weight: 10
 ---
 
 ## What is OpenCue?

--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -5,6 +5,14 @@ linkTitle: "Getting started"
 weight: 2
 date: 2019-02-22
 description: >
-  Deploying OpenCue components and installing dependencies
+  Guides for deploying OpenCue components and installing dependencies for System Administrators
 ---
 
+*   [Checking out the source code](/docs/getting-started/checking-out-the-source-code)
+*   [Installing PyCue and PyOutline](/docs/getting-started/installing-pycue-and-pyoutline)
+*   [Setting up the database](/docs/getting-started/setting-up-the-database)
+*   [Deploying Cuebot](/docs/getting-started/deploying-cuebot)
+*   [Deploying RQD](/docs/getting-started/deploying-rqd)
+*   [Installing CueGUI](/docs/getting-started/installing-cuegui)
+*   [Installing CueSubmit](/docs/getting-started/installing-cuesubmit)
+*   [Installing CueAdmin](/docs/getting-started/installing-cueadmin)

--- a/content/en/docs/Other guides/_index.md
+++ b/content/en/docs/Other guides/_index.md
@@ -6,12 +6,9 @@ weight: 4
 date: 2019-02-22
 description: >
   Guides for common tasks related to managing, supporting, and troubleshooting
-  OpenCue
+  OpenCue for System Administrators and Technical Directors
 ---
 
-This is the section landing page.
-
-* Summarize
-* Your section
-* Here
+*   [Troubleshooting deployment](/docs/other-guides/troubleshooting-deployment)
+*   [Troubleshooting rendering](/docs/other-guides/troubleshooting-rendering)
 

--- a/content/en/docs/Reference/_index.md
+++ b/content/en/docs/Reference/_index.md
@@ -3,11 +3,7 @@ title: "Reference"
 linkTitle: "Reference"
 weight: 5
 description: >
-  A short lead descripton about this section page. Text here can also be **bold** or _italic_ and can even be split over multiple paragraphs.
+  Reference guides for OpenCue tools and interfaces for all users
 ---
 
-This is the section landing page.
-
-* Summarize
-* Your section
-* Here
+*   [CueGUI reference](/docs/reference/cuegui-reference)

--- a/content/en/docs/User guides/_index.md
+++ b/content/en/docs/User guides/_index.md
@@ -5,12 +5,12 @@ linkTitle: "User guides"
 weight: 3
 date: 2019-02-22
 description: >
-  Guides for completing common user OpenCue tasks
+  Guides for completing common user OpenCue tasks for Artists and Wranglers
 ---
 
 This is the section landing page.
 
 * Summarize
 * Your section
-* Here
+* Here]
 

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,8 +1,13 @@
 ---
 title: "OpenCue overview"
 linkTitle: "Documentation"
-weight: 20
-menu:
-  main:
-    weight: 20
+description: >
+  All OpenCue documentation
 ---
+
+*   [Concepts](/docs/concepts)
+*   [Getting started](/docs/getting-started)
+*   [User guides](/docs/user-guides)
+*   [Other guides](/docs/other-guides)
+*   [Reference](/docs/reference)
+*   [Contribution guidelines](/docs/contribution-guidelines)


### PR DESCRIPTION
Update opencue.io index navigation for the various docs sections.

Eventually, the plan is for Docsy to support auto-generation of index files to display the contents of a docs section. For now, I'm adding the links to each of the index files manually.

Also updates config.toml to add custom links to the overview and other resources.

Staged at:

https://5c7fd67df6105f000a0b4696--elated-haibt-1b47ff.netlify.com/