### PR TITLE
Update and rename _index.md to announcing-opencue-v0.1.91-release.md

### DIFF
--- a/content/en/blog/releases/_index.md
+++ b/content/en/blog/releases/_index.md
@@ -1,8 +1,0 @@
-
----
-title: "New Releases"
-linkTitle: "Releases"
-weight: 20
----
-
-

--- a/content/en/blog/releases/announcing-opencue-v0.1.91-release.md
+++ b/content/en/blog/releases/announcing-opencue-v0.1.91-release.md
@@ -1,0 +1,19 @@
+---
+title: "Announcing the release of OpenCue v0.1.91"
+linkTitle: "Version v0.1.91 release"
+date: 2019-02-27
+description: "OpenCue v0.1.91 release notes"
+---
+
+ v0.1.91 of OpenCue includes the following changes and updates:
+
+*   Cuebot writes warn and error messages to stdout [#191](https://github.com/imageworks/OpenCue/pull/191).
+*   Fixed submitting dependent jobs from PyOutline [#192](https://github.com/imageworks/OpenCue/pull/192).
+*   CueSubmit dialog is now resizable and scrollable [#205](https://github.com/imageworks/OpenCue/pull/205).
+*   Server error messages are now sent to clients making API requests [#59](https://github.com/imageworks/OpenCue/pull/59).
+*   Added support for indexing on FrameSet objects [#200](https://github.com/imageworks/OpenCue/pull/200).
+*   Updated CueGUI settings file path and default settings file [#212](https://github.com/imageworks/OpenCue/pull/212).
+*   Updated validators on CueSubmit [#199](https://github.com/imageworks/OpenCue/pull/199).
+*   Fixed filtering on CueGUI monitor frame [#203](https://github.com/imageworks/OpenCue/pull/203).
+*   Added support to allow periods in the validators for CueSubmit [#216](https://github.com/imageworks/OpenCue/pull/216).
+*   You can now configure the root log directory [#180](https://github.com/imageworks/OpenCue/pull/180).


### PR DESCRIPTION
Adding release notes for v0.1.91. More posts to follow.

Staged at:

https://5c82658e1b163900080fa587--elated-haibt-1b47ff.netlify.com/blog/2019/02/27/announcing-the-release-of-opencue-v0.1.91/