### PR TITLE
Release notes

### DIFF
--- a/content/en/blog/releases/announcing-opencue-v0.1.91-release.md
+++ b/content/en/blog/releases/announcing-opencue-v0.1.91-release.md
@@ -5,7 +5,8 @@ date: 2019-02-27
 description: "OpenCue v0.1.91 release notes"
 ---
 
-v0.1.91 of OpenCue includes the following changes and updates:
+[v0.1.91 of OpenCue](https://github.com/imageworks/OpenCue/releases/tag/v0.1.91)
+includes the following changes and updates:
 
 *   Cuebot writes warn and error messages to stdout
     [#191](https://github.com/imageworks/OpenCue/pull/191).

--- a/content/en/blog/releases/announcing-opencue-v0.1.91-release.md
+++ b/content/en/blog/releases/announcing-opencue-v0.1.91-release.md
@@ -1,6 +1,6 @@
 ---
 title: "Announcing the release of OpenCue v0.1.91"
-linkTitle: "Version v0.1.91 release"
+linkTitle: "v0.1.91 release"
 date: 2019-02-27
 description: "OpenCue v0.1.91 release notes"
 ---

--- a/content/en/blog/releases/announcing-opencue-v0.1.96-release.md
+++ b/content/en/blog/releases/announcing-opencue-v0.1.96-release.md
@@ -1,0 +1,14 @@
+---
+title: "Announcing the release of OpenCue v0.1.96"
+linkTitle: "Version v0.1.96 release"
+date: 2019-03-07
+description: "OpenCue v0.1.96 release notes"
+---
+
+v0.1.96 of OpenCue includes the following changes and updates:
+
+*   The monitor job view now updates after a job completes.
+    [#191](https://github.com/imageworks/OpenCue/pull/226).
+*   Fixed an issue with CueSubmit QSettings returning a
+    unicode string instead of a list.
+    [#192](https://github.com/imageworks/OpenCue/pull/232).

--- a/content/en/blog/releases/announcing-opencue-v0.1.96-release.md
+++ b/content/en/blog/releases/announcing-opencue-v0.1.96-release.md
@@ -1,6 +1,6 @@
 ---
 title: "Announcing the release of OpenCue v0.1.96"
-linkTitle: "Version v0.1.96 release"
+linkTitle: "v0.1.96 release"
 date: 2019-03-07
 description: "OpenCue v0.1.96 release notes"
 ---

--- a/content/en/blog/releases/announcing-opencue-v0.1.96-release.md
+++ b/content/en/blog/releases/announcing-opencue-v0.1.96-release.md
@@ -5,10 +5,11 @@ date: 2019-03-07
 description: "OpenCue v0.1.96 release notes"
 ---
 
-v0.1.96 of OpenCue includes the following changes and updates:
+[v0.1.96 of OpenCue](https://github.com/imageworks/OpenCue/releases/tag/v0.1.96)
+includes the following changes and updates:
 
 *   The monitor job view now updates after a job completes.
-    [#191](https://github.com/imageworks/OpenCue/pull/226).
+    [#226](https://github.com/imageworks/OpenCue/pull/226).
 *   Fixed an issue with CueSubmit QSettings returning a
     unicode string instead of a list.
-    [#192](https://github.com/imageworks/OpenCue/pull/232).
+    [#232](https://github.com/imageworks/OpenCue/pull/232).


### PR DESCRIPTION
Update v0.1.91 release notes with a shorter link title and add a link to repo release page.
Add v0.1.96 release notes.

Staged at:

https://5c89028bd297300008abc995--elated-haibt-1b47ff.netlify.com/blog/2019/02/27/announcing-the-release-of-opencue-v0.1.91/

https://5c89028bd297300008abc995--elated-haibt-1b47ff.netlify.com/blog/2019/03/07/announcing-the-release-of-opencue-v0.1.96/