### PR TITLE
Season of Docs blog post

### DIFF
--- a/content/en/blog/news/season-of-docs.md
+++ b/content/en/blog/news/season-of-docs.md
@@ -1,0 +1,58 @@
+---
+title: "Season of Docs 2019"
+linkTitle: "Season of Docs 2019"
+date: 2019-04-18
+description: "OpenCue is applying to take part in Season of Docs 2019"
+---
+
+The OpenCue project is aiming to grow our docs to support developers who are
+integrating OpenCue with related Media infrastructure, such as asset management
+or transcoding systems. This would include both proprietary systems, as well as
+popular commercial project management tools, such as
+[Shotgun](https://www.shotgunsoftware.com/) and
+[Ftrack](https://www.ftrack.com/).
+
+We’re very interested in growing our developer docs more generally, so student
+contributors can use the following ideas as a starting point or propose their
+own ideas to grow our developer docs!
+
+## Writing getting started guides for OpenCue plugin development
+
+OpenCue maintains a set of plugins for various content creation apps that ease
+the process of launching OpenCue jobs. These plugins make use of the OpenCue
+Python API and [Qt (PySide2)](https://pypi.org/project/PySide2/).
+
+This set of plugins is currently quite small, and the OpenCue docs don't yet
+provide a set of getting started guides for plugin development. When such a
+doc set exists we can share it with our user base and enable third party users
+and developers to contribute their own plugins.
+
+Particpating in this project could allow you to develop and demonstrate the
+following skills:
+
+*   Researching a developer's user journey
+*   Planning a doc set
+*   Drafting original developer guides
+*   Working collaboratively with a development team through peer reviews
+*   Publishing developer docs on an existing site
+
+## Writing a developer tutorial for OpenCue integration
+
+The OpenCue docs don’t yet include dedicated guides to help developers learn
+how to integrate OpenCue into existing Media infrastructure using the PyCue
+API. A developer guide, such as a codelab or tutorial series could help
+illustrate working with the OpenCue API using sample code.
+
+Participating in this project could allow you to develop and demonstrate
+the following skills:
+
+*   Conducting developer requirements research
+*   Planning technical training materials, including sample code
+*   Drafting original developer content such as codelabs or tutorials
+*   Working collaboratively with a development team through peer reviews
+*   Publishing developer docs on an existing site
+
+## Contact us
+
+To contact the OpenCue development team, email us at
+<opencue-dev@googlegroups.com>.

--- a/content/en/blog/news/season-of-docs.md
+++ b/content/en/blog/news/season-of-docs.md
@@ -56,3 +56,5 @@ the following skills:
 
 To contact the OpenCue development team, email us at
 <opencue-dev@googlegroups.com>.
+
+The OpenCue team


### PR DESCRIPTION
I thought I would add the Season of Docs proposal as a blog post so we can use this PR for final review. After we merge this PR to opencue.io, I'll cross post it to the Wiki as well.

Staged at

https://5cb893260a3a5a0008fc52e2--elated-haibt-1b47ff.netlify.com/blog/2019/04/18/season-of-docs-2019/