### PR TITLE
Update robots.txt

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = ""
+baseURL = "https://opencue.io"
 title = "OpenCue"
 
 enableRobotsTXT = true

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Sitemap: {{ .Site.BaseURL }}/sitemap.xml


### PR DESCRIPTION
Add sitemap information.

opencue.io is already dynamically generating a sitemap, published at: https://opencue.io/sitemap.xml

This PR:

- Updates the baseURL parameter in config.toml to reflect the current address.
- Adds a robots.txt template that generates a pointer to the sitemap.

Staged at:

https://5cf67238aff80400080c9baa--elated-haibt-1b47ff.netlify.com/robots.txt